### PR TITLE
nerfs the cakehat (not a shitpost)

### DIFF
--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -61,8 +61,8 @@
 
 /obj/item/clothing/head/hardhat/cakehat/turn_on()
 	..()
-	force = 15
-	throwforce = 15
+	force = 5
+	throwforce = 5
 	damtype = BURN
 	hitsound = 'sound/items/welder.ogg'
 	START_PROCESSING(SSobj, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the cakehat do 5 damage, the same as a lighter, instead of 15. The cakehat is OP, please merge.

## Why It's Good For The Game

It's pretty retarded that a single candle on a meme hat is treated as an infinite fuel welder in combat.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Balances the cakehat to be more consistent with similar items.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
